### PR TITLE
docs: note MCP server pairing for pushing generated blocks to WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,33 @@ npm run wp-env:start   # Local WordPress
 
 ---
 
+## Push generated blocks into a live WordPress install
+
+The skills generate block markup as a string. If you want your AI
+assistant to also push that markup into a real WordPress site (read
+the current page, find a container by id or text, swap children, write
+back), pair this repo with an MCP server that exposes a write surface
+for WordPress.
+
+[Respira for WordPress](https://github.com/respira-press/respira-wordpress)
+is one such MCP server. Its native Gutenberg adapter round-trips
+`generateblocks/element`, `generateblocks/text`, `generateblocks/media`,
+and `generateblocks/shape` byte-faithfully, and supports
+snapshot-before-write with one-click rollback for safe iteration.
+
+Typical pairing:
+
+```
+Read skills/generateblocks-layouts/SKILL.md, then generate a
+testimonial grid with 3 cards and use the Respira MCP to insert
+it as a new section at the top of /about on my staging site.
+```
+
+Any Gutenberg-aware MCP server works the same way. The skills here
+are server-agnostic.
+
+---
+
 ## Other LLMs
 
 For non-Claude assistants (GPT, Gemini, etc.), see **`AGENTS.md`** for universal instructions — or just run `./install.sh` to set up your tool automatically.


### PR DESCRIPTION
hi gaurav,

thanks for shipping these skills — clean, well-documented, the
generateblocks v2 naming-rules cheatsheet alone is gold.

a customer asked us this week how to wire your skills up so the
generated markup actually lands in their WordPress install rather
than just being block markup in a chat window. seemed worth a
docs nudge for anyone else hitting the same question.

this PR adds a short section after the Development block
explaining that the skills generate markup as strings and can be
paired with any Gutenberg-aware MCP server. I used Respira for
WordPress (the one I maintain) as the concrete example since it
round-trips the generateblocks v2 block types byte-faithfully,
but the framing is server-agnostic — happy to genericise
further, reword however you'd like, or drop entirely if you'd
rather keep the README focused on the skill content itself.

no changes to skills, examples, installer, or any source. README
only.

mihai
respira-press